### PR TITLE
Support for extracting multiple archives (& current directory + recursive modes)

### DIFF
--- a/projects/Gibbed.Dunia.Packing/BoundArchive.cs
+++ b/projects/Gibbed.Dunia.Packing/BoundArchive.cs
@@ -33,13 +33,19 @@ namespace Gibbed.Dunia.Packing
         public string FatPath { get; private set; }
         public string DatPath { get; private set; }
 
-        public BoundArchive(string fatPath, string datPath = null)
+        public static BoundArchive<TArchive, THash> Bind(string fatPath, string datPath = null)
         {
-            Fat = new TArchive();
+            var fat = new TArchive();
             using var input = File.OpenRead(fatPath);
-            Fat.Deserialize(input);
-            FatPath = fatPath;
-            DatPath = datPath ?? Path.ChangeExtension(fatPath, ".dat");
+            fat.Deserialize(input);
+            datPath ??= Path.ChangeExtension(fatPath, ".dat");
+
+            return new BoundArchive<TArchive, THash>
+            {
+                Fat = fat,
+                FatPath = fatPath,
+                DatPath = datPath
+            };
         }
     }
 }

--- a/projects/Gibbed.Dunia.Packing/BoundArchive.cs
+++ b/projects/Gibbed.Dunia.Packing/BoundArchive.cs
@@ -1,0 +1,45 @@
+﻿/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+using System;
+using System.IO;
+using Big = Gibbed.Dunia.FileFormats.Big;
+
+namespace Gibbed.Dunia.Packing
+{
+    internal sealed class BoundArchive<TArchive, THash>
+        where TArchive : Big.IArchive<THash>, new()
+    {
+        public TArchive Fat { get; private set; }
+        public string FatPath { get; private set; }
+        public string DatPath { get; private set; }
+
+        public BoundArchive(string fatPath, string datPath = null)
+        {
+            Fat = new TArchive();
+            using var input = File.OpenRead(fatPath);
+            Fat.Deserialize(input);
+            FatPath = fatPath;
+            DatPath = datPath ?? Path.ChangeExtension(fatPath, ".dat");
+        }
+    }
+}

--- a/projects/Gibbed.Dunia.Packing/Gibbed.Dunia.Packing.csproj
+++ b/projects/Gibbed.Dunia.Packing/Gibbed.Dunia.Packing.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.12" />
     <PackageReference Include="LZMA-SDK" Version="19.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
   <ItemGroup>

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -47,6 +47,8 @@ namespace Gibbed.Dunia.Packing
                 throw new ArgumentNullException(nameof(projectName));
             }
 
+            bool multiple = false;
+            bool recursive = false;
             bool showHelp = false;
             var options = new UnpackOptions()
             {
@@ -57,6 +59,7 @@ namespace Gibbed.Dunia.Packing
                 OverwriteFiles = false,
                 DifferencePath = null,
                 Verbose = false,
+                CreateSubDirectory = false,
             };
 
             var optionSet = new OptionSet()

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
+﻿/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -160,7 +160,7 @@ namespace Gibbed.Dunia.Packing
 
             var archives = fatPaths.Select(fatPath =>
             {
-                var archive = new BoundArchive<TArchive, THash>(fatPath);
+                var archive = BoundArchive<TArchive, THash>.Bind(fatPath);
                 if (options.Verbose == true)
                 {
                     Console.WriteLine(

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -94,7 +94,7 @@ namespace Gibbed.Dunia.Packing
 
             if (extras.Count < 1 || extras.Count > 2 || showHelp == true)
             {
-                Console.WriteLine("Usage: {0} [OPTIONS]+ input_fat [output_dir]", Helpers.GetExecutableName());
+                Console.WriteLine("Usage: {0} [OPTIONS]+ input_path [output_dir]", Helpers.GetExecutableName());
                 Console.WriteLine();
                 Console.WriteLine("Unpack files from a Big File (FAT/DAT pair).");
                 Console.WriteLine();

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -182,7 +182,7 @@ namespace Gibbed.Dunia.Packing
                 Console.WriteLine("Loading file lists...");
             }
 
-            var context = new ExtractionContext<TArchive, THash>(
+            var context = new UnpackContext<TArchive, THash>(
                 project,
                 archives,
                 outputPath: extras.Count > 1 ? extras[1] : Path.ChangeExtension(sourcePath, null) + "_unpack",
@@ -309,7 +309,7 @@ namespace Gibbed.Dunia.Packing
 
         private static void ExtractArchive(
             BoundArchive<TArchive, THash> archive,
-            ExtractionContext<TArchive, THash> context,
+            UnpackContext<TArchive, THash> context,
             UnpackOptions options)
         {
             THash[] hashDifference = null;

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -103,31 +103,54 @@ namespace Gibbed.Dunia.Packing
                 return;
             }
 
-            string fatPath = extras[0];
-            string outputPath = extras.Count > 1 ? extras[1] : Path.ChangeExtension(fatPath, null) + "_unpack";
-            string datPath;
-
-            Regex filter = null;
-            if (string.IsNullOrEmpty(filterPattern) == false)
-            {
-                filter = new Regex(filterPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            }
-
-            if (Path.GetExtension(fatPath) == ".dat")
-            {
-                datPath = fatPath;
-                fatPath = Path.ChangeExtension(fatPath, ".fat");
-            }
-            else
-            {
-                datPath = Path.ChangeExtension(fatPath, ".dat");
-            }
-
             var projectPath = Helpers.GetProjectPath(projectName);
             if (File.Exists(projectPath) == false)
             {
                 Console.WriteLine($"Project file '{projectPath}' is missing!");
                 return;
+            }
+
+            if (options.Verbose == true)
+            {
+                Console.WriteLine("Loading project...");
+            }
+
+            var project = ProjectData.Project.Load(projectPath);
+            if (project == null)
+            {
+                Console.WriteLine("Failed to load project!");
+                return;
+            }
+
+            string[] fatPaths;
+            string sourcePath = extras[0];
+
+            if (recursive == true && multiple == false)
+            {
+                Console.WriteLine("Warning: [recursive] has no effect when [multiple] is not set");
+            }
+
+            if (multiple)
+            {
+                if (!Directory.Exists(sourcePath))
+                {
+                    Console.WriteLine($"Input path \"{sourcePath}\" should be a directory path when [multiple] is set.");
+                    return;
+                }
+                fatPaths = Directory.GetFiles(sourcePath, "*.fat", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+            }
+            else
+            {
+                if (Path.GetExtension(sourcePath) == ".dat")
+                {
+                    sourcePath = Path.ChangeExtension(sourcePath, ".fat");
+                }
+                fatPaths = new string[] { sourcePath };
+            }
+
+            if (options.Verbose)
+            {
+                Console.WriteLine($"Loading {(fatPaths.Length == 1 ? "FAT" : $"{fatPaths.Length} FATs")}...");
             }
 
             if (verbose == true)

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -68,6 +68,7 @@ namespace Gibbed.Dunia.Packing
                 { "nf|no-files", "don't extract files", v => options.ExtractFiles = v == null },
                 { "nu|no-unknowns", "don't extract unknown files", v => options.ExtractUnknowns = v == null },
                 { "ou|only-unknowns", "only extract unknown files", v => options.OnlyUnknowns = v != null },
+                { "f|filter=", "only extract files using pattern", v => options.Filter = !string.IsNullOrEmpty(v) ? new Regex(v) : null },
                 { "f|filter=", "only extract files using pattern", v => filterPattern = v },
                 { "if|invert-filter", "only extract files not using pattern", v => invertFilter = v != null },
                 { "d|difference=", "only extract files aren't in specified archive", v => differencePath = v },

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
+/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -70,7 +70,7 @@ namespace Gibbed.Dunia.Packing
                 { "nf|no-files", "don't extract files", v => options.ExtractFiles = v == null },
                 { "nu|no-unknowns", "don't extract unknown files", v => options.ExtractUnknowns = v == null },
                 { "ou|only-unknowns", "only extract unknown files", v => options.OnlyUnknowns = v != null },
-                { "f|filter=", "only extract files using pattern", v => options.Filter = !string.IsNullOrEmpty(v) ? new Regex(v) : null },
+                { "f|filter=", "only extract files using pattern", v => options.Filter = string.IsNullOrEmpty(v) == false ? new Regex(v) : null },
                 { "if|invert-filter", "only extract files not using pattern", v => options.InvertFilter = v != null },
                 { "d|difference=", "only extract files aren't in specified archive", v => options.DifferencePath = v },
                 { "m|multiple", "extract all archives from [input_path]", v => multiple = v != null },
@@ -132,9 +132,9 @@ namespace Gibbed.Dunia.Packing
                 Console.WriteLine("Warning: [recursive] has no effect when [multiple] is not set");
             }
 
-            if (multiple)
+            if (multiple == true)
             {
-                if (!Directory.Exists(sourcePath))
+                if (Directory.Exists(sourcePath) == false)
                 {
                     Console.WriteLine($"Input path \"{sourcePath}\" should be a directory path when [multiple] is set.");
                     return;
@@ -150,7 +150,7 @@ namespace Gibbed.Dunia.Packing
                 fatPaths = new string[] { sourcePath };
             }
 
-            if (options.Verbose)
+            if (options.Verbose == true)
             {
                 Console.WriteLine($"Loading {(fatPaths.Length == 1 ? "FAT" : $"{fatPaths.Length} FATs")}...");
             }
@@ -170,7 +170,7 @@ namespace Gibbed.Dunia.Packing
 
             if (archives.Length == 0)
             {
-                if (options.Verbose)
+                if (options.Verbose == true)
                 {
                     Console.WriteLine($"No archives found from \"{sourcePath}\" (recursive: {recursive})");
                 }
@@ -189,7 +189,7 @@ namespace Gibbed.Dunia.Packing
                 tryGetHashOverride
             );
 
-            if (options.Verbose)
+            if (options.Verbose == true)
             {
                 Console.WriteLine(
                     $"Beginning to extract {context.TotalEntryCount} " +
@@ -199,7 +199,7 @@ namespace Gibbed.Dunia.Packing
 
             Parallel.ForEach(archives, archive => ExtractArchive(archive, context, options));
 
-            if (options.Verbose)
+            if (options.Verbose == true)
             {
                 Console.WriteLine(
                     $"Finished extracting {context.TotalEntryCount} " +

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -71,6 +71,9 @@ namespace Gibbed.Dunia.Packing
                 { "f|filter=", "only extract files using pattern", v => options.Filter = !string.IsNullOrEmpty(v) ? new Regex(v) : null },
                 { "if|invert-filter", "only extract files not using pattern", v => options.InvertFilter = v != null },
                 { "d|difference=", "only extract files aren't in specified archive", v => options.DifferencePath = v },
+                { "m|multiple", "extract all archives from [input_path]", v => multiple = v != null },
+                { "r|recursive", "extract all archives from [input_path] and its sub-directories", v => recursive = v != null },
+                { "sd|subdir", "create a sub-directory per archive", v => options.CreateSubDirectory = v != null },
                 { "v|verbose", "be verbose", v => options.Verbose = v != null },
                 { "h|help", "show this message and exit", v => showHelp = v != null },
             };

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -69,10 +69,9 @@ namespace Gibbed.Dunia.Packing
                 { "nu|no-unknowns", "don't extract unknown files", v => options.ExtractUnknowns = v == null },
                 { "ou|only-unknowns", "only extract unknown files", v => options.OnlyUnknowns = v != null },
                 { "f|filter=", "only extract files using pattern", v => options.Filter = !string.IsNullOrEmpty(v) ? new Regex(v) : null },
-                { "f|filter=", "only extract files using pattern", v => filterPattern = v },
-                { "if|invert-filter", "only extract files not using pattern", v => invertFilter = v != null },
-                { "d|difference=", "only extract files aren't in specified archive", v => differencePath = v },
-                { "v|verbose", "be verbose", v => verbose = v != null },
+                { "if|invert-filter", "only extract files not using pattern", v => options.InvertFilter = v != null },
+                { "d|difference=", "only extract files aren't in specified archive", v => options.DifferencePath = v },
+                { "v|verbose", "be verbose", v => options.Verbose = v != null },
                 { "h|help", "show this message and exit", v => showHelp = v != null },
             };
 

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
+/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -48,13 +48,13 @@ namespace Gibbed.Dunia.Packing
             }
 
             bool showHelp = false;
-            bool verbose = false;
             var options = new UnpackOptions()
             {
                 ExtractUnknowns = true,
                 OnlyUnknowns = false,
                 ExtractFiles = true,
                 OverwriteFiles = false,
+                Verbose = false,
             };
             string filterPattern = null;
             bool invertFilter = false;

--- a/projects/Gibbed.Dunia.Packing/Unpack.cs
+++ b/projects/Gibbed.Dunia.Packing/Unpack.cs
@@ -52,13 +52,12 @@ namespace Gibbed.Dunia.Packing
             {
                 ExtractUnknowns = true,
                 OnlyUnknowns = false,
+                Filter = null,
                 ExtractFiles = true,
                 OverwriteFiles = false,
+                DifferencePath = null,
                 Verbose = false,
             };
-            string filterPattern = null;
-            bool invertFilter = false;
-            string differencePath = null;
 
             var optionSet = new OptionSet()
             {

--- a/projects/Gibbed.Dunia.Packing/UnpackContext.cs
+++ b/projects/Gibbed.Dunia.Packing/UnpackContext.cs
@@ -29,7 +29,7 @@ using System.Threading;
 
 namespace Gibbed.Dunia.Packing
 {
-    internal sealed class ExtractionContext<TArchive, THash>
+    internal sealed class UnpackContext<TArchive, THash>
         where TArchive : Big.IArchive<THash>, new()
     {
         public List<(string archiveName, long totalCount, long extractedCount, long IgnoredCount, long ExcludedCount, long ExistingCount)> Tallies { get; private set; } = new();
@@ -42,7 +42,7 @@ namespace Gibbed.Dunia.Packing
         private ProjectData.HashList<THash> hashes;
         public ProjectData.HashList<THash> Hashes => hashes;
 
-        public ExtractionContext(
+        public UnpackContext(
             ProjectData.Project project,
             BoundArchive<TArchive, THash>[] archives,
             string outputPath,

--- a/projects/Gibbed.Dunia.Packing/UnpackContext.cs
+++ b/projects/Gibbed.Dunia.Packing/UnpackContext.cs
@@ -1,0 +1,67 @@
+﻿/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+using System;
+using Gibbed.Dunia.FileFormats;
+using System.Collections.Generic;
+using System.Linq;
+using Big = Gibbed.Dunia.FileFormats.Big;
+using System.Threading;
+
+namespace Gibbed.Dunia.Packing
+{
+    internal sealed class ExtractionContext<TArchive, THash>
+        where TArchive : Big.IArchive<THash>, new()
+    {
+        public List<(string archiveName, long totalCount, long extractedCount, long IgnoredCount, long ExcludedCount, long ExistingCount)> Tallies { get; private set; } = new();
+        public string OutputPath { get; private set; }
+        public long TotalEntryCount { get; private set; } = 0;
+
+        private long processedEntryCount = 0;
+        public long ProcessedEntryCount => processedEntryCount;
+
+        private ProjectData.HashList<THash> hashes;
+        public ProjectData.HashList<THash> Hashes => hashes;
+
+        public ExtractionContext(
+            ProjectData.Project project,
+            BoundArchive<TArchive, THash>[] archives,
+            string outputPath,
+            Big.TryGetHashOverride<THash> tryGetHashOverride)
+        {
+            TotalEntryCount = archives.Sum(archive => archive.Fat.Entries.Count);
+            OutputPath = outputPath;
+            project.LoadListsFileNames(
+                (string s) => archives.First().Fat.ComputeNameHash(s, tryGetHashOverride), out hashes);
+        }
+
+        public void Tally(string archiveName, long total, long extracted, long ignored, long excluded, long existing)
+        {
+            Tallies.Add((archiveName, total, extracted, ignored, excluded, existing));
+        }
+
+        public void IncrementProcessedEntryCount()
+        {
+            Interlocked.Increment(ref processedEntryCount);
+        }
+    }
+}

--- a/projects/Gibbed.Dunia.Packing/UnpackOptions.cs
+++ b/projects/Gibbed.Dunia.Packing/UnpackOptions.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
+/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -20,13 +20,19 @@
  *    distribution.
  */
 
+using System.Text.RegularExpressions;
+
 namespace Gibbed.Dunia.Packing
 {
     internal struct UnpackOptions
     {
         public bool ExtractUnknowns;
         public bool OnlyUnknowns;
+        public Regex Filter;
         public bool ExtractFiles;
         public bool OverwriteFiles;
+        public string DifferencePath;
+        public bool InvertFilter;
+        public bool Verbose;
     }
 }

--- a/projects/Gibbed.Dunia.Packing/UnpackOptions.cs
+++ b/projects/Gibbed.Dunia.Packing/UnpackOptions.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
+﻿/* Copyright (c) 2021 Rick (rick 'at' gibbed 'dot' us)
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -34,5 +34,6 @@ namespace Gibbed.Dunia.Packing
         public string DifferencePath;
         public bool InvertFilter;
         public bool Verbose;
+        public bool CreateSubDirectory;
     }
 }


### PR DESCRIPTION
- Should we **not** indent console output when `[multiple]` is not set?
- Should we keep the console output as similar to the current implementation as possible when `[multiple]` is not set?
